### PR TITLE
[CLEANUP] Fix ticks on colorbars showing time

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -46,7 +46,7 @@ A good bug report shouldn't leave others needing to chase you up for more inform
 <!-- omit in toc -->
 ### Suggesting Enhancements
 
-This section guides you through submitting an enhancement suggestion for XYZ, **including completely new features and minor improvements to existing functionality**. 
+This section guides you through submitting an enhancement suggestion for glidertest, **including completely new features and minor improvements to existing functionality**. 
 
 <!-- omit in toc -->
 #### Before Submitting an Enhancement
@@ -63,7 +63,7 @@ Enhancement suggestions are tracked as [GitHub issues](https://github.com/OceanG
 - Use a **clear and descriptive title** for the issue to identify the suggestion.
 - Provide a **step-by-step description of the suggested enhancement** in as many details as possible.
 - **Describe the current behavior** and **explain which behavior you expected to see instead** and why. At this point you can also tell which alternatives do not work for you.
-- **Explain why this enhancement would be useful** to most XYZ users. 
+- **Explain why this enhancement would be useful** to most glidertest users. 
 
 ### Your First Code Contribution
 

--- a/glidertest/tools.py
+++ b/glidertest/tools.py
@@ -264,7 +264,6 @@ def quant_binavg(ds, var='VERT_CURR', zgrid=None, dz=None):
 
     Notes
     ----
-    - I know this is a non-sensical name.  We should re-name, but is based on advice from Ramsey Harcourt.
     Original Author: Eleanor Frajka-Williams
     """
     utilities._check_necessary_variables(ds, [var, 'PRES'])

--- a/glidertest/utilities.py
+++ b/glidertest/utilities.py
@@ -49,24 +49,24 @@ def _calc_teos10_variables(ds):
     return ds
 
 def _time_axis_formatter(ax, ds, format_x_axis=True):
-    start_time = ds.TIME.min().values
-    end_time = ds.TIME.max().values
-    if (end_time - start_time) < np.timedelta64(1, 'D'):
-        formatter = DateFormatter('%H:%M')
-        locator = mdates.HourLocator(interval=2)
-        start_date = pd.to_datetime(start_time).strftime('%Y-%b-%d')
-        end_date = pd.to_datetime(end_time).strftime('%Y-%b-%d')
-        xlabel = f'Time [UTC] ({start_date})' if start_date == end_date else f'Time [UTC] ({start_date} to {end_date})'
-    elif (end_time - start_time) < np.timedelta64(7, 'D'):
-        formatter = DateFormatter('%d-%b')
-        locator = mdates.DayLocator(interval=1)
-        start_date = pd.to_datetime(start_time).strftime('%Y-%b-%d')
-        end_date = pd.to_datetime(end_time).strftime('%Y-%b-%d')
-        xlabel = f'Time [UTC] ({start_date})' if start_date == end_date else f'Time [UTC] ({start_date} to {end_date})'
-    else:
-        formatter = DateFormatter('%d-%b')
-        locator = None
-        xlabel = 'Time [UTC]'
+    """
+    Apply time formatter and locator to an axis.
+
+    Parameters
+    ----------
+    ax : matplotlib axis
+        Axis to format.
+    ds : xarray.Dataset
+        Dataset containing TIME coordinate.
+    format_x_axis : bool, default=True
+        Whether to format the x-axis (True) or y-axis (False).
+    """
+    formatter, locator, xlabel = _select_time_formatter_and_locator(ds)
+
+    axis = ax.xaxis if format_x_axis else ax.yaxis
+    axis.set_major_formatter(formatter)
+    if locator:
+        axis.set_major_locator(locator)
 
     if format_x_axis:
         ax.xaxis.set_major_formatter(formatter)
@@ -79,6 +79,85 @@ def _time_axis_formatter(ax, ds, format_x_axis=True):
             ax.yaxis.set_major_locator(locator)
         ax.set_ylabel(xlabel)
         
+
+def _select_time_formatter_and_locator(ds):
+    """
+    Select appropriate time formatter and locator based on time range.
+
+    Parameters
+    ----------
+    ds : xarray.Dataset
+        Dataset containing TIME coordinate.
+
+    Returns
+    -------
+    formatter : matplotlib.dates.DateFormatter
+        Formatter for time axis or colorbar.
+    locator : matplotlib.dates.Locator or None
+        Locator for axis ticks (None if not needed).
+    xlabel : str
+        Label for the axis (optional for colorbars).
+    """
+    start_time = ds.TIME.min().values
+    end_time = ds.TIME.max().values
+    time_range_hours = (end_time - start_time) / np.timedelta64(1, 'h')
+
+    if time_range_hours < 24:
+        formatter = DateFormatter('%H:%M')
+        # Dynamic interval based on time range
+        if time_range_hours <= 6:
+            interval = 1
+        elif time_range_hours <= 12:
+            interval = 2
+        else:
+            interval = 3
+        locator = mdates.HourLocator(byhour=range(0, 24, 2))
+        start_date = pd.to_datetime(start_time).strftime('%Y-%b-%d')
+        end_date = pd.to_datetime(end_time).strftime('%Y-%b-%d')
+        xlabel = f'Time [UTC] ({start_date})' if start_date == end_date else f'Time [UTC] ({start_date} to {end_date})'
+    elif time_range_hours < 24 * 7:
+        formatter = DateFormatter('%d-%b')
+        locator = mdates.DayLocator(interval=1)
+        start_date = pd.to_datetime(start_time).strftime('%Y-%b-%d')
+        end_date = pd.to_datetime(end_time).strftime('%Y-%b-%d')
+        xlabel = f'Time [UTC] ({start_date})' if start_date == end_date else f'Time [UTC] ({start_date} to {end_date})'
+    else:
+        formatter = DateFormatter('%d-%b')
+        locator = None
+        xlabel = 'Time [UTC]'
+
+    return formatter, locator, xlabel
+
+def set_colorbar_time_ticks(colorbar, locator, color_array):
+    """
+    Set ticks on a time-based colorbar using the provided locator.
+
+    Parameters
+    ----------
+    colorbar : matplotlib.colorbar.Colorbar
+        Colorbar object to update.
+    locator : matplotlib.dates.Locator
+        Locator for determining tick positions.
+    color_array : numpy.ndarray
+        Data array used for color values (numeric date format).
+    """
+    color_min = color_array.min()
+    color_max = color_array.max()
+
+    # Skip manual ticks if range is too small
+    if (color_max - color_min) < 1e-3:
+        return
+
+    vmin_dt = mdates.num2date(color_min)
+    vmax_dt = mdates.num2date(color_max)
+    ticks = locator.tick_values(vmin_dt, vmax_dt)
+
+    # Filter ticks within data range
+    ticks = [tick for tick in ticks if color_min <= tick <= color_max]
+    # Apply ticks if we have any
+    if ticks:
+        colorbar.set_ticks(mdates.date2num(ticks))
+
 def construct_2dgrid(x, y, v, xi=1, yi=1):
     """
     Constructs a 2D gridded representation of input data based on specified resolutions.

--- a/glidertest/utilities.py
+++ b/glidertest/utilities.py
@@ -128,35 +128,6 @@ def _select_time_formatter_and_locator(ds):
 
     return formatter, locator, xlabel
 
-def set_colorbar_time_ticks(colorbar, locator, color_array):
-    """
-    Set ticks on a time-based colorbar using the provided locator.
-
-    Parameters
-    ----------
-    colorbar : matplotlib.colorbar.Colorbar
-        Colorbar object to update.
-    locator : matplotlib.dates.Locator
-        Locator for determining tick positions.
-    color_array : numpy.ndarray
-        Data array used for color values (numeric date format).
-    """
-    color_min = color_array.min()
-    color_max = color_array.max()
-
-    # Skip manual ticks if range is too small
-    if (color_max - color_min) < 1e-3:
-        return
-
-    vmin_dt = mdates.num2date(color_min)
-    vmax_dt = mdates.num2date(color_max)
-    ticks = locator.tick_values(vmin_dt, vmax_dt)
-
-    # Filter ticks within data range
-    ticks = [tick for tick in ticks if color_min <= tick <= color_max]
-    # Apply ticks if we have any
-    if ticks:
-        colorbar.set_ticks(mdates.date2num(ticks))
 
 def construct_2dgrid(x, y, v, xi=1, yi=1):
     """

--- a/notebooks/demo.ipynb
+++ b/notebooks/demo.ipynb
@@ -34,7 +34,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "id": "429c3105",
    "metadata": {},
    "outputs": [],
@@ -119,6 +119,8 @@
    "outputs": [],
    "source": [
     "# Basic plot of the location of the dataset in space/time\n",
+    "import importlib\n",
+    "importlib.reload(plots)\n",
     "plots.plot_glider_track(ds)"
    ]
   },
@@ -934,7 +936,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "venv",
    "language": "python",
    "name": "python3"
   },
@@ -948,7 +950,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.8"
+   "version": "3.9.6"
   }
  },
  "nbformat": 4,

--- a/notebooks/demo.ipynb
+++ b/notebooks/demo.ipynb
@@ -119,8 +119,6 @@
    "outputs": [],
    "source": [
     "# Basic plot of the location of the dataset in space/time\n",
-    "import importlib\n",
-    "importlib.reload(plots)\n",
     "plots.plot_glider_track(ds)"
    ]
   },


### PR DESCRIPTION
Time axes on color bars, specifically for `plots.plot_glider_track()` and `plots.check_temporal_drift()` showed the same date over and over again (for time ranges shorter than 1 day).

Now updated by editing functions in utilities:
- from `_time_axis_formatter()`, abstracted the part of the function that selects the ticks
- Put this abstracted part into `_select_time_formatter_and_locator`
- Added function `set_colorbar_time_ticks(colorbar, locator, color_array)`, but then realised it wouldn't quite do it.

The code for the fixes now lies in the two plot functions.  Not beautiful, but redoes scatter using numeric values for time, and  manually sets the ticks on the colorbars.

- Also small fix to CONTRIBUTING.MD to change XYZ--> glidertest
![CleanShot 2025-04-14 at 22 40 17@2x](https://github.com/user-attachments/assets/5a7944af-2fb0-4ac0-a506-46b7109127bf)
<img width="685" alt="Screenshot 2025-04-14 at 22 40 29" src="https://github.com/user-attachments/assets/c951dda5-2903-4c76-ae33-eb8553355ed2" />
