### PR TITLE
add north atlantic seaglider mission

### DIFF
--- a/glidertest/fetchers.py
+++ b/glidertest/fetchers.py
@@ -20,6 +20,7 @@ data_source_og = pooch.create(
         'sg014_20040924T182454_delayed.nc': 'sha256:c9fca08ce676573224c04512f4d5bfe251d0419478ee433dfefa03aa70e2eb9a',
         'sg014_20040924T182454_delayed_subset.nc': 'sha256:0e97a4107364d27364d076ed8007f08c891b2015b439cf524a44612de0a1a2ea',
         'sg015_20050213T230253_delayed.nc': 'sha256:ca64e33e9f317e1fc3442e74485a9bf5bb1b4a81b5728e9978847b436e0586ab',
+        "sg638_20191205T121839_delayed.nc": "sha256:d67021237bfe707cc0cd11f09a0d009f15504eefbaf1bd45dfbba8a2700a229a",
     },
 )
 


### PR DESCRIPTION
This adds the seaglider mission contributed by @tillmrtz that I have uploaded to the sample missions site   
https://erddap.observations.voiceoftheocean.org/examples/glidertest/