### PR TITLE
[FEAT] interactive notebook, tests and function rename

### DIFF
--- a/glidertest/interactive.py
+++ b/glidertest/interactive.py
@@ -56,7 +56,7 @@ def mission_map(ds):
         ).add_to(m)
     return m
 
-def interactive_profile(ds):
+def profile(ds):
     """
     Creates an interactive profile viewer with external slider inputs.
 
@@ -134,7 +134,7 @@ def interactive_profile(ds):
     display(ui, out)
 
 
-def interactive_up_down_bias(ds):
+def up_down_bias(ds):
     """
     Creates an interactive up/down bias plot with external slider inputs.
 
@@ -174,7 +174,7 @@ def interactive_up_down_bias(ds):
 
     display(ui, out)
 
-def interactive_daynight_avg(ds):
+def daynight_avg(ds):
     """
     Creates an interactive day/night average plot with external slider inputs.
 
@@ -217,7 +217,7 @@ def interactive_daynight_avg(ds):
 
     display(ui, out)
 
-def interactive_ts_plot(ds):
+def ts_plot(ds):
     """
     Creates an interactive temperature-salinity plot with external slider inputs.
 

--- a/notebooks/interactive.ipynb
+++ b/notebooks/interactive.ipynb
@@ -1,0 +1,116 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "9d181e37-766d-41e1-8153-676bd740868b",
+   "metadata": {},
+   "source": [
+    "# Interactive\n",
+    "\n",
+    "This notebook demonstrates the interactive functionality of `glidertest`. All of the interactive functions are in the `glidertest.interactive` module"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9187047d-1605-4c7b-b804-c9263204eefe",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from glidertest import fetchers, interactive"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9100eb39-8939-48bf-92aa-eef6598c385a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ds = fetchers.load_sample_dataset()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6cdc914f-f742-495f-90fb-cbe5c82e3af1",
+   "metadata": {},
+   "source": [
+    "### Map\n",
+    "We can make a leaflet-style map with [folium](https://python-visualization.github.io/folium)\n",
+    "\n",
+    "This can be more convenient than a static map with e.g. cartopy. You can zoom the map and hover over each point to see the dive number"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "16ddabe2-2d4e-418d-9f4a-f739b018db10",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "interactive.mission_map(ds)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4e9475a0-1114-4e77-b66f-cd648034cda7",
+   "metadata": {},
+   "source": [
+    "### Interactive profile\n",
+    "\n",
+    "The interactive profile plots enable the user to visualise individual profiles and overlay up to three variables in one plot. This produces a figure familiar to that of a classic vessel CTD, but with much more flexibility."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "67098c7f-21c6-4111-a0a7-d9e0e20c49f6",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "interactive.profile(ds)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5e73758f-6419-4118-a9b6-7ea0f7971337",
+   "metadata": {},
+   "source": [
+    "### daynight average\n",
+    "\n",
+    "`interactive.daynight_avg` allows the dynamic comparison of daily and nightly average profiles for all variables"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "cdb5b3cf-ecc0-470e-a7ac-dcb0df7264d6",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "interactive.daynight_avg(ds)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.12"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/tests/test_interactive.py
+++ b/tests/test_interactive.py
@@ -1,6 +1,16 @@
 from glidertest import fetchers, interactive
-import pytest
+import matplotlib
+matplotlib.use('agg')  # use agg backend to prevent creating plot windows during tests
+
+ds = fetchers.load_sample_dataset()
+
 
 def test_mission_map():
-    ds = fetchers.load_sample_dataset()
     interactive.mission_map(ds)
+
+def test_interactive_profiles():
+    interactive.profile(ds)
+    interactive.ts_plot(ds)
+    interactive.daynight_avg(ds)
+    interactive.up_down_bias(ds)
+    


### PR DESCRIPTION
This PR adds a notebook showcasing the interactive plots. It also adds tests to cover all the interactive functions as well as a small rename to remove the redundant interactive from `glidertest.interactive.interactive_<function_name>`